### PR TITLE
Fixes and changes towards a usable metrics module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-
+settings.cfg
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/bluesky/settings.py
+++ b/bluesky/settings.py
@@ -59,13 +59,13 @@ for i in range(len(sys.argv)):
 
 if not os.path.isfile(configfile):
     print
-    print '\033[91mNo config file settings.cfg found in your BlueSky starting directory!\033[0m'
+    print 'No config file settings.cfg found in your BlueSky starting directory!'
     print
     print 'This config file contains several default settings related to the simulation loop and the graphics'
     print 'You can specify your own settings or use the default.'
     print 'Leave empty to use the default settings.'
     print
-    manual_input = (raw_input('Do you want to want to define your own settings? \033[1m(yes/[no])\033[0m: ').lower().find('y') >= 0)
+    manual_input = (raw_input('Do you want to want to define your own settings? (yes/[no]): ').lower().find('y') >= 0)
     print
     lines = ''
     with open(os.path.dirname(__file__) + '/settings.py') as fin:
@@ -75,7 +75,7 @@ if not os.path.isfile(configfile):
                 if len(line) > 0 and line[0] != '#' and line.find('=') >= 0:
                     # Get input from user
                     c = line.split('=')
-                    ans = raw_input('\033[1m[' + c[1].strip(' \'') + ']\033[0m: ')
+                    ans = raw_input('[' + c[1].strip(' \'') + ']: ')
                     if len(ans) > 0:
                         line = c[0] + ' = '
                         if c[1].find('\'') >= 0:

--- a/bluesky/tools/aero.py
+++ b/bluesky/tools/aero.py
@@ -270,7 +270,7 @@ def latlondist(lat1,lon1,lat2,lon2):
 
 # Calculate average local earth radius
     if lat1*lat2>0.:  # same hemisphere
-        r = rwgs(0.5*(lat1+lat2))    
+        r = rwgs84(0.5*(lat1+lat2))    
 
     else:             # different hemisphere
         a = 6378137.0       # [m] Major semi-axis WGS-84

--- a/bluesky/ui/pygame/screen.py
+++ b/bluesky/ui/pygame/screen.py
@@ -510,10 +510,10 @@ class Screen:
 
                 #FIR CIRCLE
                 if traf.area == "Circle":
-                    lat2_circle, lon2_circle = qdrpos(traf.metric.fir_circle_point[0], traf.metric.fir_circle_point[1],
-                                                      180, traf.metric.fir_circle_radius)
+                    lat2_circle, lon2_circle = qdrpos(sim.metric.fir_circle_point[0], sim.metric.fir_circle_point[1],
+                                                      180, sim.metric.fir_circle_radius)
 
-                    x_circle, y_circle = self.ll2xy(traf.metric.fir_circle_point[0], traf.metric.fir_circle_point[1])
+                    x_circle, y_circle = self.ll2xy(sim.metric.fir_circle_point[0], sim.metric.fir_circle_point[1])
                     x2_circle, y2_circle = self.ll2xy(lat2_circle, lon2_circle)
                     radius = int(abs(y2_circle - y_circle))
 


### PR DESCRIPTION
METRICS module is now usable again.

It seems like the metrics instance used to be part of the traf instance but was restructured to fall directly under the sim object, because of this I've made the changes below to make it usable again under the current structure.

- Many modules previously used the metrics instance as traf.metrics. This is now sim.metrics.
- All function calls involving the metrics module no longer pass the traf instance but instead the sim instance which also contains traf.
- Changes to the stack module now process the relevant metrics commands correctly
- The metrics module is disabled by default, it can be enabled by issuing the command: METRICS ON
- Various small variable name fixes

TODO:
- Make similar changes to Qt simulation file as have been done int he Pygame version

See atached scenario file to test metrics module:
[00-metricstest.txt](https://github.com/ProfHoekstra/bluesky/files/51187/00-metricstest.txt)