### PR TITLE
fixed synthetic.py scr.zoom call

### DIFF
--- a/bluesky/stack/synthetic.py
+++ b/bluesky/stack/synthetic.py
@@ -31,7 +31,7 @@ def process(command, numargs, commandargs, sim, traf, scr, cmd):
         scr.redrawradbg=True    #draw the background again
         scr.swsep = True        #show circles of seperation between ac
         scr.swspd = True        #show speed vectors of aircraft
-        scr.zoom(1,False)       #set zoom level to the standard distance
+        #scr.zoom(1)       #set zoom level to the standard distance
         #cmd.scenlines=[]       #skip the rest of the scenario
         #cmd.scenlines.append("00:00:00.00>"+callsign+"TESTCIRCLE")
         #cmd.scenlines.append("00:00:00.00>DT 1")


### PR DESCRIPTION
It doesn't really do something: scr.zoom(1,false), the line was commented out since the call was also done incorrectly and crashed the synthetics module in pygame.